### PR TITLE
Potential fix for code scanning alert no. 16: Database query built from user-controlled sources

### DIFF
--- a/controllers/auth-controller.js
+++ b/controllers/auth-controller.js
@@ -75,7 +75,12 @@ exports.loginUser = async (req, res) => {
     const { email, password } = req.body;
 
     // Validation
-    if (!email || !password) {
+    if (
+      typeof email !== "string" ||
+      typeof password !== "string" ||
+      email.trim() === "" ||
+      password.trim() === ""
+    ) {
       return res.status(400).json({
         status_code: 400,
         message: "Email and password are required",


### PR DESCRIPTION
Potential fix for [https://github.com/Aryan3522/Auth-Application/security/code-scanning/16](https://github.com/Aryan3522/Auth-Application/security/code-scanning/16)

In general, to fix NoSQL injection when building MongoDB/Mongoose queries from user input, ensure untrusted values are treated as literals, or validate that they are primitive types (e.g., strings) instead of objects that may contain query operators. This can be done by either using operators like `$eq` explicitly, or by checking `typeof value === "string"` (or matching an expected pattern) before using it in a query.

For this code, the best minimal fix without changing functionality is:
- In `loginUser`, validate that `email` is a non-empty string (and `password` as well) before using them.
- Reject the request with a 400 error if `email` (or `password`) is missing or not a string.
- Optionally, you can also wrap `email` inside `$eq` in the query, but type-checking is sufficient and simpler.

Concretely:
- In `controllers/auth-controller.js`, within `exports.loginUser`, extend the validation block around lines 75–83 to additionally verify `typeof email === "string"` and `typeof password === "string"` and that they are not just whitespace.
- Keep using `User.findOne({ email })` after these checks; once we guarantee `email` is a string, the taint cannot produce an operator object.

No new imports are required; we only add simple type and emptiness checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
