### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
-    "mongoose": "^9.0.2"
+    "mongoose": "^9.0.2",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.11"

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const express = require("express");
 const path = require("path");
 const connectDB = require("./config/db");
+const rateLimit = require("express-rate-limit");
 
 const app = express();
 
@@ -12,14 +13,20 @@ connectDB();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+// Rate limiting for HTML routes
+const htmlLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
 // Serve HTML
-app.get("/", (req, res) => {
+app.get("/", htmlLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, "views", "home.html"));
 });
-app.get("/login", (req, res) => {
+app.get("/login", htmlLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, "views", "login.html"));
 });
-app.get("/register", (req, res) => {
+app.get("/register", htmlLimiter, (req, res) => {
   res.sendFile(path.join(__dirname, "views", "register.html"));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Aryan3522/Auth-Application/security/code-scanning/14](https://github.com/Aryan3522/Auth-Application/security/code-scanning/14)

In general, the problem is fixed by introducing a rate-limiting middleware that caps how many requests a given client (typically identified by IP) can make in a given time window, and applying it to routes that perform file system access or other expensive operations. For Express, a standard solution is the `express-rate-limit` package.

For this codebase, the safest change that doesn’t alter existing behavior (other than throttling abusive traffic) is:

- Import `express-rate-limit` near the top of `server.js`.
- Configure a reasonable limiter (e.g., 100 requests per 15 minutes per IP).
- Apply this limiter as middleware to the specific HTML-serving routes (including `/register`, which is flagged), or optionally to all routes. To stay focused on the CodeQL finding, we can at least apply it to the three `app.get` routes that call `sendFile`.

Concretely:

- In `server.js`, after existing `require` statements, add `const rateLimit = require("express-rate-limit");`.
- Define a limiter variable, e.g. `const htmlLimiter = rateLimit({ windowMs: ..., max: ... });`.
- Update the three `app.get` calls to include this middleware as the second argument: `app.get("/register", htmlLimiter, (req, res) => { ... });` and similarly for `/` and `/login`. This keeps route logic intact and only adds rate limiting.

No other files need changing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
